### PR TITLE
Add option to change score range for raids command

### DIFF
--- a/cogs/military.py
+++ b/cogs/military.py
@@ -114,7 +114,11 @@ class TargetFinding(commands.Cog):
         name="raids",
         description="Find raid targets",
     )
-    async def raids(self, ctx: discord.ApplicationContext):
+    async def raids(
+        self, 
+        ctx: discord.ApplicationContext,
+        score: Option(float, "Set a custom score range.") = None
+        ):
         try:
             await ctx.defer()
             
@@ -129,8 +133,12 @@ class TargetFinding(commands.Cog):
                 await ctx.edit(content='I did not find that person!')
                 return
             
-            minscore = round(atck_ntn['score'] * 0.75)
-            maxscore = round(atck_ntn['score'] * 2.5)
+            if score:
+                minscore = round(score * 0.75)
+                maxscore = round(score * 2.5)
+            else:
+                minscore = round(atck_ntn['score'] * 0.75)
+                maxscore = round(atck_ntn['score'] * 2.5)
             
             use_same = None
             class stage_one(discord.ui.View):


### PR DESCRIPTION
Only affects the score range in which the bot will find raids, all reminders are still attributed to the author of command, military calculations are also done by their nation.