### PR TITLE
fix: beige loot $0 caused by deprecated loot_info parsing

### DIFF
--- a/logic/common.py
+++ b/logic/common.py
@@ -9,6 +9,22 @@ from typing import Any, Dict, Optional
 RSS = ['aluminum', 'bauxite', 'coal', 'food', 'gasoline', 'iron', 'lead', 'money', 'munitions', 'oil', 'steel', 'uranium', 'credits']
 EMBED_COLOR = 0xff5100  # Orange color used throughout Autolycus embeds
 
+# Resource order matches legacy loot_info strings and GraphQL ``*_looted`` fields.
+BEIGE_LOOT_RESOURCES: tuple[str, ...] = (
+    'money',
+    'coal',
+    'oil',
+    'uranium',
+    'iron',
+    'bauxite',
+    'lead',
+    'gasoline',
+    'munitions',
+    'steel',
+    'aluminum',
+    'food',
+)
+
 
 def cut_string(string: str, length: int = 2000) -> str:
     if len(string) > length:
@@ -37,18 +53,17 @@ def get_datetime_of_turns(turns: int) -> datetime:
 def beige_loot_value(loot_string: str, prices: dict[str, float]) -> int:
     loot_string = loot_string[loot_string.index('$'):loot_string.index('Food.')]
     loot_string = re.sub(r"[^0-9-]+", "", loot_string.replace(", ", "-"))
-    rss = ['money', 'coal', 'oil', 'uranium', 'iron', 'bauxite', 'lead', 'gasoline', 'munitions', 'steel', 'aluminum', 'food']
     n = 0
     loot: dict[str, int] = {}
     for sub in loot_string.split("-"):
-        loot[rss[n]] = int(sub)
+        loot[BEIGE_LOOT_RESOURCES[n]] = int(sub)
         n += 1
-    nation_loot = 0
-    for rs in rss:
+    nation_loot = 0.0
+    for rs in BEIGE_LOOT_RESOURCES:
         amount = loot[rs]
-        price = int(prices[rs])
+        price = float(prices[rs])
         nation_loot += amount * price
-    return nation_loot
+    return int(round(nation_loot))
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +91,107 @@ def parse_war_date(date_str: Optional[str]) -> datetime:
         return datetime.fromtimestamp(0, tz=timezone.utc)
 
 
+def _price_for(prices: dict[str, float], resource: str) -> float:
+    if resource == 'money':
+        return 1.0
+    raw = prices.get(resource)
+    if raw is None:
+        return 0.0
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _looted_field_name(resource: str) -> str:
+    return 'money_looted' if resource == 'money' else f'{resource}_looted'
+
+
+def attack_has_structured_loot(attack: dict[str, Any]) -> bool:
+    """True when the attack payload includes GraphQL ``*_looted`` fields."""
+    return any(_looted_field_name(rs) in attack for rs in BEIGE_LOOT_RESOURCES)
+
+
+def structured_beige_loot_value(attack: dict[str, Any], prices: dict[str, float]) -> Optional[float]:
+    """Market value of victory loot from GraphQL ``*_looted`` fields.
+
+    ``loot_info`` is deprecated on the Politics & War API ("No longer in use").
+    Victory / beige loot is exposed as ``money_looted`` plus ``{resource}_looted``.
+    Returns *None* when the attack has no structured loot payload at all.
+    """
+    if not attack_has_structured_loot(attack):
+        return None
+    total = 0.0
+    for resource in BEIGE_LOOT_RESOURCES:
+        raw = attack.get(_looted_field_name(resource))
+        if raw is None:
+            continue
+        try:
+            amount = float(raw)
+        except (TypeError, ValueError):
+            continue
+        total += amount * _price_for(prices, resource)
+    return total
+
+
+def _attack_beige_loot_market_value(
+    attack: dict[str, Any],
+    prices: dict[str, float],
+) -> Optional[float]:
+    """Resolve beige loot market value for one attack.
+
+    Prefers structured ``*_looted`` fields; falls back to legacy ``loot_info``
+    text parsing for older cached war rows.
+    """
+    structured = structured_beige_loot_value(attack, prices)
+    if structured is not None:
+        return structured
+
+    text = attack.get('loot_info')
+    if not text or "won the war and looted" not in str(text):
+        return None
+    try:
+        return float(beige_loot_value(str(text), prices))
+    except Exception:
+        return None
+
+
+def _is_beige_loot_attack(attack: dict[str, Any], nation_id: str) -> bool:
+    """True when *attack* is a victory loot event against *nation_id*."""
+    victor = str(attack.get('victor', '') or '')
+    if victor and victor == nation_id:
+        return False  # they won, so this is not their beige loot
+
+    attack_type = str(attack.get('type') or '').upper()
+    if attack_type == 'ALLIANCELOOT':
+        return False  # alliance bank loot, not nation beige loot
+    if attack_type == 'VICTORY':
+        return True
+
+    # Legacy cached rows: only loot_info text identified beige loot.
+    text = attack.get('loot_info')
+    return bool(text and "won the war and looted" in str(text))
+
+
+def _undo_loot_multipliers(loot_value: float, war: dict[str, Any]) -> float:
+    """Reverse attacker policy / war-type multipliers to estimate base loot."""
+    attacker_info = war.get('attacker') or {}
+    policy = (attacker_info.get('war_policy') or '').upper()
+    if policy == "ATTRITION":
+        loot_value = loot_value / 0.8
+    elif policy == "PIRATE":
+        loot_value = loot_value / 1.4
+    if attacker_info.get('advanced_pirate_economy'):
+        loot_value = loot_value / 1.1
+
+    war_type = (war.get('war_type') or '').upper()
+    if war_type == "ATTRITION":
+        loot_value *= 4
+    elif war_type == "ORDINARY":
+        loot_value *= 2
+    return loot_value
+
+
 def compute_beige_loot(
     nation: dict[str, Any],
     prices: Optional[dict[str, float]],
@@ -86,6 +202,10 @@ def compute_beige_loot(
     defender and lost, then reverse-engineers the *base* loot value by
     undoing attacker policy / war-type multipliers.  This gives a rough
     estimate of how much loot the nation is holding.
+
+    Prefers GraphQL structured ``money_looted`` / ``*_looted`` fields because
+    ``loot_info`` is deprecated and commonly empty. Falls back to parsing
+    legacy ``loot_info`` strings when structured fields are absent.
 
     The function performs a single linear pass (no sorting) over the wars
     list to find the most recent qualifying war.
@@ -112,7 +232,7 @@ def compute_beige_loot(
 
     for war in wars:
         try:
-            turns_left = war.get('turnsleft', 1)
+            turns_left = war.get('turnsleft', war.get('turns_left', 1))
             try:
                 turns_left_val = float(turns_left)
             except (TypeError, ValueError):
@@ -120,41 +240,22 @@ def compute_beige_loot(
             if turns_left_val > 0:
                 continue  # still active
 
-            if str(war.get('defid')) != nation_id:
+            def_id = war.get('defid', war.get('def_id'))
+            if str(def_id) != nation_id:
                 continue  # only care about wars where this nation was defender
 
             war_dt = parse_war_date(war.get('date'))
             attacks = war.get('attacks') or []
 
             for attack in reversed(attacks):  # reverse to favour latest attack
-                text = attack.get('loot_info')
-                if not text or "won the war and looted" not in text:
-                    continue
-                victor = str(attack.get('victor', ''))
-                if victor == nation_id:
-                    continue  # they won, so no beige loot
-
-                try:
-                    loot_value = float(beige_loot_value(text, prices))
-                except Exception:
+                if not _is_beige_loot_attack(attack, nation_id):
                     continue
 
-                # Undo attacker policy multipliers to estimate base loot
-                attacker_info = war.get('attacker') or {}
-                policy = (attacker_info.get('war_policy') or '').upper()
-                if policy == "ATTRITION":
-                    loot_value = loot_value / 0.8
-                elif policy == "PIRATE":
-                    loot_value = loot_value / 1.4
-                if attacker_info.get('advanced_pirate_economy'):
-                    loot_value = loot_value / 1.1
+                loot_value = _attack_beige_loot_market_value(attack, prices)
+                if loot_value is None:
+                    continue
 
-                # Undo war-type multipliers
-                war_type = (war.get('war_type') or '').upper()
-                if war_type == "ATTRITION":
-                    loot_value *= 4
-                elif war_type == "ORDINARY":
-                    loot_value *= 2
+                loot_value = _undo_loot_multipliers(float(loot_value), war)
 
                 if best_date is None or war_dt > best_date:
                     best_date = war_dt

--- a/logic/queries.py
+++ b/logic/queries.py
@@ -9,7 +9,25 @@ PRICES = {"tradeprices": ["coal", "oil", "uranium", "iron", "bauxite", "lead", "
 
 
 # backgraound.py
-WARS_SCANNER = {"wars": ["id", "war_type", "att_peace", "def_peace", "turnsleft", "reason", "date", "att_id", "def_id", "att_alliance_id", "def_alliance_id", {"attacker": ["nation_name", "leader_name", {"alliance": ["name"]}, "alliance_id", "id", "num_cities"]}, {"defender": ["nation_name", "leader_name", {"alliance": ["name"]}, "alliance_id", "id", "num_cities"]}, {"attacks": ["type", "id", "date", "att_id", "def_id", "loot_info", "victor", "moneystolen", "success", "cityid", "resistance_eliminated", "infra_destroyed", "infra_destroyed_value", "improvements_destroyed", "att_soldiers_lost", "def_soldiers_lost", "att_tanks_lost", "def_tanks_lost", "att_aircraft_lost", "def_aircraft_lost", "att_ships_lost", "def_ships_lost", "money_destroyed"]}]}
+_WAR_ATTACK_LOOT_FIELDS = [
+    "type",
+    "loot_info",
+    "victor",
+    "moneystolen",
+    "money_looted",
+    "coal_looted",
+    "oil_looted",
+    "uranium_looted",
+    "iron_looted",
+    "bauxite_looted",
+    "lead_looted",
+    "gasoline_looted",
+    "munitions_looted",
+    "steel_looted",
+    "aluminum_looted",
+    "food_looted",
+]
+WARS_SCANNER = {"wars": ["id", "war_type", "att_peace", "def_peace", "turnsleft", "reason", "date", "att_id", "def_id", "att_alliance_id", "def_alliance_id", {"attacker": ["nation_name", "leader_name", {"alliance": ["name"]}, "alliance_id", "id", "num_cities"]}, {"defender": ["nation_name", "leader_name", {"alliance": ["name"]}, "alliance_id", "id", "num_cities"]}, {"attacks": ["id", "date", "att_id", "def_id", "success", "cityid", "resistance_eliminated", "infra_destroyed", "infra_destroyed_value", "improvements_destroyed", "att_soldiers_lost", "def_soldiers_lost", "att_tanks_lost", "def_tanks_lost", "att_aircraft_lost", "def_aircraft_lost", "att_ships_lost", "def_ships_lost", "money_destroyed"] + _WAR_ATTACK_LOOT_FIELDS}]}
 
 
 # config.py
@@ -32,7 +50,7 @@ WAR_STATUS = (MILITARIZATION_CHECKER, BATTLE_CALC, {"nations": WAR_STATUS_DEPEND
 
 
 # scanner.py
-BACKGROUND_SCANNER = {"nations": ["id", "discord", "leader_name", "nation_name", "warpolicy", "vacation_mode_turns", "flag", "last_active", "alliance_position_id", "continent", "fallout_shelter", "guiding_satellite", "military_salvage", "pirate_economy", "advanced_pirate_economy", "warpolicy", "resource_production_center", "government_support_agency", "bureau_of_domestic_affairs", "dompolicy", "vds", "irond", "population", "alliance_id", "beige_turns", "score", "color", "spies", "soldiers", "tanks", "aircraft", "ships", "missiles", "nukes", {"bounties": ["amount", "type"]}, {"treasures": ["name"]}, {"alliance": ["name", "id", "color", "flag"]}, {"wars": ["date", "winner", {"attacker": ["war_policy", "advanced_pirate_economy"]}, {"defender": ["war_policy", "advanced_pirate_economy"]}, "war_type", "defid", "turnsleft", {"attacks": ["loot_info", "victor", "moneystolen"]}]}, "alliance_position", "num_cities", "ironw", "bauxitew", "armss", "egr", "massirr", "itc", "recycling_initiative", "telecom_satellite", "green_tech", "clinical_research_center", "specialized_police_training", "uap", {"military_research": ['ground_cost', 'ground_capacity', 'air_cost', 'air_capacity', 'naval_cost', 'naval_capacity']}, {"cities": ["date", "powered", "infrastructure", "land", "oilpower", "windpower", "coalpower", "nuclearpower", "coalmine", "oilwell", "uramine", "barracks", "farm", "policestation", "hospital", "recyclingcenter", "subway", "supermarket", "bank", "mall", "stadium", "leadmine", "ironmine", "bauxitemine", "gasrefinery", "aluminumrefinery", "steelmill", "munitionsfactory", "factory", "airforcebase", "drydock"]}]}
+BACKGROUND_SCANNER = {"nations": ["id", "discord", "leader_name", "nation_name", "warpolicy", "vacation_mode_turns", "flag", "last_active", "alliance_position_id", "continent", "fallout_shelter", "guiding_satellite", "military_salvage", "pirate_economy", "advanced_pirate_economy", "warpolicy", "resource_production_center", "government_support_agency", "bureau_of_domestic_affairs", "dompolicy", "vds", "irond", "population", "alliance_id", "beige_turns", "score", "color", "spies", "soldiers", "tanks", "aircraft", "ships", "missiles", "nukes", {"bounties": ["amount", "type"]}, {"treasures": ["name"]}, {"alliance": ["name", "id", "color", "flag"]}, {"wars": ["date", "winner", {"attacker": ["war_policy", "advanced_pirate_economy"]}, {"defender": ["war_policy", "advanced_pirate_economy"]}, "war_type", "defid", "turnsleft", {"attacks": list(_WAR_ATTACK_LOOT_FIELDS)}]}, "alliance_position", "num_cities", "ironw", "bauxitew", "armss", "egr", "massirr", "itc", "recycling_initiative", "telecom_satellite", "green_tech", "clinical_research_center", "specialized_police_training", "uap", {"military_research": ['ground_cost', 'ground_capacity', 'air_cost', 'air_capacity', 'naval_cost', 'naval_capacity']}, {"cities": ["date", "powered", "infrastructure", "land", "oilpower", "windpower", "coalpower", "nuclearpower", "coalmine", "oilwell", "uramine", "barracks", "farm", "policestation", "hospital", "recyclingcenter", "subway", "supermarket", "bank", "mall", "stadium", "leadmine", "ironmine", "bauxitemine", "gasrefinery", "aluminumrefinery", "steelmill", "munitionsfactory", "factory", "airforcebase", "drydock"]}]}
 TRANSACTIONS_DEPENDENCY = ["id", "date", "sender_id", "sender_type", "receiver_id", "receiver_type", "banker_id", "note", "money", "coal", "oil", "uranium", "iron", "bauxite", "lead", "gasoline", "munitions", "steel", "aluminum", "food"]
 TRANSACTIONS = {"alliances": [{"bankrecs": TRANSACTIONS_DEPENDENCY}, {"taxrecs": TRANSACTIONS_DEPENDENCY}]}
 

--- a/tests/test_beige_loot.py
+++ b/tests/test_beige_loot.py
@@ -1,0 +1,204 @@
+"""Tests for beige loot valuation (structured GraphQL fields + legacy loot_info)."""
+
+from __future__ import annotations
+
+from logic.common import (
+    beige_loot_value,
+    compute_beige_loot,
+    structured_beige_loot_value,
+)
+from logic import queries
+from logic.merge_utils import get_query
+
+
+SAMPLE_PRICES = {
+    "money": 1,
+    "coal": 10,
+    "oil": 20,
+    "uranium": 30,
+    "iron": 40,
+    "bauxite": 50,
+    "lead": 60,
+    "gasoline": 70,
+    "munitions": 80,
+    "steel": 90,
+    "aluminum": 100,
+    "food": 5,
+}
+
+
+def _victory_attack(**overrides):
+    attack = {
+        "type": "VICTORY",
+        "victor": "999",
+        "loot_info": None,
+        "money_looted": 1_000_000,
+        "coal_looted": 10,
+        "oil_looted": 0,
+        "uranium_looted": 0,
+        "iron_looted": 0,
+        "bauxite_looted": 0,
+        "lead_looted": 0,
+        "gasoline_looted": 0,
+        "munitions_looted": 0,
+        "steel_looted": 0,
+        "aluminum_looted": 0,
+        "food_looted": 100,
+    }
+    attack.update(overrides)
+    return attack
+
+
+def test_structured_beige_loot_value_sums_resources():
+    attack = _victory_attack()
+    # 1_000_000*1 + 10*10 + 100*5 = 1_000_000 + 100 + 500 = 1_000_600
+    assert structured_beige_loot_value(attack, SAMPLE_PRICES) == 1_000_600.0
+
+
+def test_structured_beige_loot_value_none_without_fields():
+    assert structured_beige_loot_value({"type": "GROUND", "moneystolen": 500}, SAMPLE_PRICES) is None
+
+
+def test_compute_beige_loot_uses_structured_fields_when_loot_info_empty():
+    """Reproduce production failure mode: loot_info deprecated/empty, *_looted present."""
+    nation = {
+        "id": "55556",
+        "wars": [
+            {
+                "date": "2026-08-17T19:43:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "PIRATE", "advanced_pirate_economy": False},
+                "attacks": [
+                    {"type": "GROUND", "victor": "999", "moneystolen": 123},
+                    _victory_attack(),
+                ],
+            }
+        ],
+    }
+    loot = compute_beige_loot(nation, SAMPLE_PRICES)
+    # RAID has no war-type undo; PIRATE divides by 1.4
+    assert loot == int(round(1_000_600 / 1.4))
+
+
+def test_compute_beige_loot_returns_none_when_only_empty_loot_info():
+    """Legacy path: empty loot_info and no structured fields → no value (shows as $0)."""
+    nation = {
+        "id": "55556",
+        "wars": [
+            {
+                "date": "2026-08-17T19:43:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [
+                    {"loot_info": None, "victor": "999", "moneystolen": 0},
+                ],
+            }
+        ],
+    }
+    assert compute_beige_loot(nation, SAMPLE_PRICES) is None
+
+
+def test_compute_beige_loot_falls_back_to_loot_info_text():
+    loot_info = (
+        "Sparkle won the war and looted $16,754, 77 Coal, 11 Oil, 19 Uranium, "
+        "68 Iron, 5 Bauxite, 15 Lead, 52 Gasoline, 242 Munitions, 31 Steel, "
+        "35 Aluminum, and 2,422 Food. Kingdom of Svearmark also lost 4% of the "
+        "infrastructure in each of their cities."
+    )
+    nation = {
+        "id": "55556",
+        "wars": [
+            {
+                "date": "2026-08-17T19:43:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [
+                    {"loot_info": loot_info, "victor": "999"},
+                ],
+            }
+        ],
+    }
+    expected = beige_loot_value(loot_info, SAMPLE_PRICES)
+    assert compute_beige_loot(nation, SAMPLE_PRICES) == expected
+    assert expected > 0
+
+
+def test_compute_beige_loot_skips_alliance_loot():
+    nation = {
+        "id": "55556",
+        "wars": [
+            {
+                "date": "2026-08-17T19:43:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [
+                    _victory_attack(type="ALLIANCELOOT", money_looted=9_999_999),
+                ],
+            }
+        ],
+    }
+    assert compute_beige_loot(nation, SAMPLE_PRICES) is None
+
+
+def test_compute_beige_loot_prefers_most_recent_finished_defensive_war():
+    nation = {
+        "id": "55556",
+        "wars": [
+            {
+                "date": "2026-07-01T00:00:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [_victory_attack(money_looted=100)],
+            },
+            {
+                "date": "2026-08-17T00:00:00+00:00",
+                "defid": "55556",
+                "turnsleft": 0,
+                "war_type": "RAID",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [_victory_attack(money_looted=5_000_000, coal_looted=0, food_looted=0)],
+            },
+        ],
+    }
+    assert compute_beige_loot(nation, SAMPLE_PRICES) == 5_000_000
+
+
+def test_compute_beige_loot_ordinary_war_type_multiplier():
+    nation = {
+        "id": "1",
+        "wars": [
+            {
+                "date": "2026-08-17T00:00:00+00:00",
+                "defid": "1",
+                "turnsleft": 0,
+                "war_type": "ORDINARY",
+                "attacker": {"war_policy": "FORTRESS"},
+                "attacks": [_victory_attack(money_looted=1000, coal_looted=0, food_looted=0)],
+            }
+        ],
+    }
+    # Ordinary undoes by *2
+    assert compute_beige_loot(nation, SAMPLE_PRICES) == 2000
+
+
+def test_background_scanner_query_requests_structured_loot_fields():
+    q = get_query(queries.BACKGROUND_SCANNER)
+    for field in (
+        "money_looted",
+        "coal_looted",
+        "food_looted",
+        "type",
+        "loot_info",
+        "victor",
+    ):
+        assert field in q

--- a/tests/test_beige_loot_live.py
+++ b/tests/test_beige_loot_live.py
@@ -1,0 +1,88 @@
+"""Optional live Politics & War API check for beige loot fields.
+
+Run with:
+  API_KEY=... PYTHONPATH=. python3 -m pytest tests/test_beige_loot_live.py -q
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from logic.common import compute_beige_loot
+
+
+# Recently beiged nation with many defensive defeats (see politicsandwar.com/nation/id=55556).
+LIVE_NATION_ID = 55556
+
+
+def _graphql(api_key: str, query: str) -> dict:
+    url = f"https://api.politicsandwar.com/graphql?api_key={api_key}"
+    response = requests.post(url, json={"query": query}, timeout=30)
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("errors"):
+        raise AssertionError(payload["errors"])
+    return payload
+
+
+def test_live_nation_has_structured_victory_loot():
+    api_key = (os.getenv("API_KEY") or "").strip()
+    if not api_key:
+        pytest.skip("API_KEY not set")
+
+    query = (
+        "{"
+        f"nations(id:{LIVE_NATION_ID},first:1)"
+        "{data{id nation_name beige_turns color "
+        "wars{"
+        "date war_type defid turnsleft "
+        "attacker{war_policy advanced_pirate_economy} "
+        "attacks{"
+        "type loot_info victor moneystolen money_looted "
+        "coal_looted oil_looted uranium_looted iron_looted bauxite_looted "
+        "lead_looted gasoline_looted munitions_looted steel_looted "
+        "aluminum_looted food_looted"
+        "}}}}}"
+        "}"
+    )
+    prices_query = (
+        "{tradeprices(first:1){data{coal oil uranium iron bauxite lead "
+        "gasoline munitions steel aluminum food}}}"
+    )
+
+    nation_resp = _graphql(api_key, query)
+    prices_resp = _graphql(api_key, prices_query)
+
+    nations = nation_resp["data"]["nations"]["data"]
+    assert nations, f"nation {LIVE_NATION_ID} not returned"
+    nation = nations[0]
+
+    prices = prices_resp["data"]["tradeprices"]["data"][0]
+    prices["money"] = 1
+
+    empty_loot_info = 0
+    structured_victory = 0
+    for war in nation.get("wars") or []:
+        if str(war.get("defid")) != str(nation["id"]):
+            continue
+        for attack in war.get("attacks") or []:
+            if (attack.get("type") or "").upper() != "VICTORY":
+                continue
+            if not attack.get("loot_info"):
+                empty_loot_info += 1
+            if attack.get("money_looted") is not None or attack.get("food_looted") is not None:
+                structured_victory += 1
+
+    assert structured_victory > 0, (
+        f"expected VICTORY attacks with *_looted fields on nation {LIVE_NATION_ID}"
+    )
+    # Document the production bug: loot_info is commonly empty while structured fields exist.
+    assert empty_loot_info > 0 or compute_beige_loot(nation, prices) not in (None, 0)
+
+    loot = compute_beige_loot(nation, prices)
+    assert loot is not None and loot > 0, (
+        f"expected non-zero beige loot for nation {LIVE_NATION_ID}, got {loot!r}"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production raids data shows **`$0` beige loot for every nation** (sampled 8k+ targets across all score bands on `autolycus.app`), including nations currently on beige with recent defensive defeats.

**Concrete example:** nation **55556** (Kingdom of Svearmark)
- On politicsandwar.com: beige, **29 Defeats** (most recent war `2686563`)
- On Autolycus `/api/raids`: `"nationLoot": "$0"`, `beigeTurns: 2`

## Root cause

Beige loot was computed only by parsing GraphQL `loot_info` text (`"won the war and looted..."`).

In the PnW schema, `loot_info` is **`@deprecated(reason: "No longer in use")`**. Victory loot is exposed as structured fields instead:

- `money_looted`
- `coal_looted`, `oil_looted`, …, `food_looted`
- attack `type: VICTORY`

When `loot_info` is empty, `compute_beige_loot()` returned `None`, the scanner left/defaulted `nation_loot_value` to 0, and `/api/raids` rendered `$0`.

## Fix

1. Prefer structured `*_looted` fields on `VICTORY` attacks (skip `ALLIANCELOOT`)
2. Fall back to legacy `loot_info` parsing for older cached rows
3. Request those fields in `BACKGROUND_SCANNER` / `WARS_SCANNER` queries
4. Add unit tests covering the empty-`loot_info` failure mode

## Deploy note

After merge, a nation scan is required so SQLite war attacks are re-fetched with the new fields and `nation_loot_value` is recomputed.

Optional live check (needs `API_KEY`):

```bash
API_KEY=... PYTHONPATH=. python3 -m pytest tests/test_beige_loot_live.py -q
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2361b96b-dfb5-47c0-bfa6-f3c7245a56c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2361b96b-dfb5-47c0-bfa6-f3c7245a56c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

