### PR TITLE
fix: unblock prod git updates (dubious ownership) + expose deploy SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,17 @@ The update timer runs every 6 hours by default. Edit
 [scripts/ops/autolycus-update.timer](scripts/ops/autolycus-update.timer) to change
 the interval.
 
+Force an update immediately (useful after merging to `master`):
+
+```
+sudo systemctl start autolycus-update.service
+sudo systemctl status autolycus-update.service --no-pager
+```
+
+If updates fail with git **dubious ownership**, either re-run `sudo scripts/ops/bootstrap.sh`
+or the update script itself now passes `safe.directory` per git command. Confirm the
+running commit via `GET /api/health` (`commit` / `syncedAt` from `data/deploy.json`).
+
 ### 6) Firewall (Oracle Linux)
 
 Allow inbound HTTP + HTTPS access:

--- a/api/app.py
+++ b/api/app.py
@@ -135,11 +135,30 @@ def create_app(config_object: Optional[object] = None) -> Flask:
     @app.route('/healthz')
     def health_check():
         """Health check endpoint for monitoring."""
-        return jsonify({
+        from pathlib import Path
+        import json as _json
+
+        deploy = None
+        deploy_path = Path(app.root_path).parent / 'data' / 'deploy.json'
+        try:
+            if deploy_path.is_file():
+                deploy = _json.loads(deploy_path.read_text(encoding='utf-8'))
+        except Exception:
+            deploy = None
+
+        payload = {
             'status': 'healthy',
             'service': 'autolycus-api',
             'version': os.getenv('version', 'unknown'),
-        }), 200
+        }
+        if isinstance(deploy, dict):
+            if deploy.get('commit'):
+                payload['commit'] = deploy.get('commit')
+            if deploy.get('branch'):
+                payload['branch'] = deploy.get('branch')
+            if deploy.get('syncedAt'):
+                payload['syncedAt'] = deploy.get('syncedAt')
+        return jsonify(payload), 200
     
     # Root endpoint
     @app.route('/')

--- a/scripts/ops/bootstrap.sh
+++ b/scripts/ops/bootstrap.sh
@@ -8,6 +8,11 @@ sudo install -m 0644 "$REPO_DIR/scripts/ops/autolycus.service" "$SYSTEMD_DIR/aut
 sudo install -m 0644 "$REPO_DIR/scripts/ops/autolycus-update.service" "$SYSTEMD_DIR/autolycus-update.service"
 sudo install -m 0644 "$REPO_DIR/scripts/ops/autolycus-update.timer" "$SYSTEMD_DIR/autolycus-update.timer"
 
+# systemd update unit runs as root; repo is often owned by a deploy user.
+sudo git config --system --add safe.directory "$REPO_DIR" || true
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now autolycus.service
 sudo systemctl enable --now autolycus-update.timer
+
+echo "Tip: force one update now with: sudo systemctl start autolycus-update.service"

--- a/scripts/ops/update.sh
+++ b/scripts/ops/update.sh
@@ -4,16 +4,43 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_DIR"
 
+# Prefer per-command safe.directory so root-run systemd updates work even when
+# /opt/autolycus is owned by a non-root user (git "dubious ownership").
+git_safe() {
+  git -c "safe.directory=$REPO_DIR" "$@"
+}
+
 # Deploy host: discard local dirt (e.g. chmod +x) and sync to remote.
 # Do not use this pattern on a machine with work you care about keeping.
+deploy_sha=""
+deploy_branch=""
+deploy_synced_at=""
 if [ -d .git ]; then
-  git fetch --prune origin
-  branch="$(git rev-parse --abbrev-ref HEAD)"
-  git reset --hard "origin/${branch}"
-  git clean -fd
-  git lfs pull --include "data/city_builds.db" || true
+  git_safe fetch --prune origin
+  deploy_branch="$(git_safe rev-parse --abbrev-ref HEAD)"
+  git_safe reset --hard "origin/${deploy_branch}"
+  git_safe clean -fd
+  git_safe lfs pull --include "data/city_builds.db" || true
+  deploy_sha="$(git_safe rev-parse HEAD)"
+  deploy_synced_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+fi
+
+mkdir -p data
+if [ -n "$deploy_sha" ]; then
+  cat > data/deploy.json <<EOF
+{
+  "commit": "${deploy_sha}",
+  "branch": "${deploy_branch}",
+  "syncedAt": "${deploy_synced_at}",
+  "source": "scripts/ops/update.sh"
+}
+EOF
 fi
 
 docker compose --profile prod build --pull
 
 docker compose --profile prod up -d --remove-orphans
+
+if [ -n "$deploy_sha" ]; then
+  echo "Deployed ${deploy_branch}@${deploy_sha} (syncedAt=${deploy_synced_at})"
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why beige loot is still $0 in prod

Very likely **the beige-loot fix never reached the VM**.

Evidence:
- A prior agent session found `autolycus-update.service` failing on git **dubious ownership** (systemd runs as root; `/opt/autolycus` owned by deploy user).
- Prod still shows `$0` beige loot for all sampled nations ~15h after PR #13 merged.
- Nation rows keep getting `updatedAt` refreshes from the *already-running* old scanner; that does not prove new code is deployed.

Container restarts do **not** `git pull`. Only the host systemd timer/`update.sh` does.

## This PR

1. `update.sh` passes `git -c safe.directory=...` on every git command (works even before bootstrap is re-run)
2. Writes `data/deploy.json` with commit/branch/syncedAt
3. `/api/health` exposes `commit` / `syncedAt` so deploy state is visible
4. `bootstrap.sh` also sets system `safe.directory`
5. README: how to force an update and verify

## Required on the VM (chicken-and-egg)

Until the new `update.sh` is on disk, run once:

```bash
sudo git config --system --add safe.directory /opt/autolycus
cd /opt/autolycus
sudo git -c safe.directory=/opt/autolycus fetch --prune origin
sudo git -c safe.directory=/opt/autolycus reset --hard origin/master
sudo bash scripts/ops/update.sh
# or: sudo systemctl start autolycus-update.service
curl -s https://autolycus.app/api/health
```

After deploy, wait for a nation scan cycle; beige loot should start filling non-zero values.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2361b96b-dfb5-47c0-bfa6-f3c7245a56c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2361b96b-dfb5-47c0-bfa6-f3c7245a56c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

